### PR TITLE
exit 1 on nonce too error

### DIFF
--- a/artifacts.py
+++ b/artifacts.py
@@ -103,4 +103,6 @@ class Artifact:
         if r.json()['status'] == 'OK':
             logging.info("\n\nBounty " + self.file.name + " sent to polyswarmd.\n\n")
         else:
+            logging.debug(r.json())
             logging.warning("BOUNTY NOT POSTED!!!!!!!!!!! CHECK TX")
+            sys.exit(1)


### PR DESCRIPTION
This change is to make sure the a `nonce too low` error causes a failure in `e2e`. This is related to this fix/issue https://github.com/polyswarm/polyswarmd/issues/39.