### PR TITLE
Feature/add offer channel integration test

### DIFF
--- a/ambassador.py
+++ b/ambassador.py
@@ -34,16 +34,17 @@ BID = os.environ.get('BID','625000000000000000')
         help='Bid for the bounties you want to submit')
 @click.option('--duration', default=BOUNTY_DURATION,
         help='How long you want the bounties to run')
-@click.option('--restart', envvar='RESTART', default=None,
-        help='How many times would you like the script to retart submitting files')
+@click.option('--testing', envvar='TESTING', default=-1,
+        help='Activate testing mode for integration testing, send N bounties and N offers then exit')
 @click.option('--api-key', envvar='API_KEY', default=API_KEY,
         help='API key to use with polyswarmd')
 
-def main(log, polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, restart, api_key):
+
+def main(log, polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, testing, api_key):
     loglevel = getattr(logging, log.upper(), None)
     priv_key = None
     address = None
-
+    testing = int(testing)
     account = '0x' + json.loads(open(keyfile,'r').read())['address']
 
     logging.debug('using account + %s + ...', ACCOUNT)
@@ -51,14 +52,11 @@ def main(log, polyswarmd_addr, keyfile, password, bounty_directory, bid, duratio
 
     run_bounties(polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, api_key, account)
 
-    if restart and int(restart) > 0:
-        for i in range(0, int(restart)):
-            logging.debug('restart: %s ...', i)
-            run_bounties(polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, api_key, account)
+    for i in range(0, testing):
+        logging.debug('testing: %s ...', i)
+        run_bounties(polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, api_key, account)
 
-    # not running offers atm because the introduction of websockets complicates e2e testing
-    # to run standalone run `python offers.py`
-    # run_offers()
+    run_offers(testing)
 
     sys.exit(0)
 

--- a/ambassador.py
+++ b/ambassador.py
@@ -20,7 +20,7 @@ BOUNTY_DURATION = os.environ.get('BOUNTY_DURATION',25)
 BID = os.environ.get('BID','625000000000000000')
 
 @click.command()
-@click.option('--log', default='DEBUG',
+@click.option('--log', default='INFO',
         help='Logging level')
 @click.option('--polyswarmd-addr', envvar='POLYSWARMD_HOST', default=HOST,
         help='Address of polyswarmd instance')
@@ -38,16 +38,17 @@ BID = os.environ.get('BID','625000000000000000')
         help='Activate testing mode for integration testing, send N bounties and N offers then exit')
 @click.option('--api-key', envvar='API_KEY', default=API_KEY,
         help='API key to use with polyswarmd')
+@click.option('--offers', envvar='OFFERS', default=False, is_flag=True,
+        help='Should the abassador send offers')
 
-
-def main(log, polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, testing, api_key):
+def main(log, polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, testing, api_key, offers):
     loglevel = getattr(logging, log.upper(), None)
     priv_key = None
     address = None
     testing = int(testing)
     account = '0x' + json.loads(open(keyfile,'r').read())['address']
 
-    logging.debug('using account + %s + ...', ACCOUNT)
+    logging.info('using account + %s + ...', ACCOUNT)
 
 
     run_bounties(polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, api_key, account)
@@ -56,7 +57,8 @@ def main(log, polyswarmd_addr, keyfile, password, bounty_directory, bid, duratio
         logging.debug('testing: %s ...', i)
         run_bounties(polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, api_key, account)
 
-    run_offers(testing)
+    if offers:
+        run_offers(testing)
 
     sys.exit(0)
 

--- a/bounties.py
+++ b/bounties.py
@@ -12,7 +12,7 @@ from web3.middleware import geth_poa_middleware
 from artifacts import File, Artifact
 
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 w3=Web3(HTTPProvider(os.environ.get('GETH_ADDR','http://geth:8545')))
 w3.middleware_stack.inject(geth_poa_middleware,layer=0)
 
@@ -25,11 +25,11 @@ def postBounties(numToPost, files, host, keyfile, password, bid, duration, api_k
         artifactArr = []
         bountyArr = []
         
-        logging.debug("trying to get nonce")
+        logging.info("trying to get nonce")
         headers = {'Authorization': api_key}
         # always put account into our requests
         nonce=json.loads(requests.get('http://'+ host + '/nonce', headers=headers, params={'account': account}).text)['result']
-        logging.debug("nonce received: "+str(nonce))
+        logging.info("nonce received: "+str(nonce))
         #create and post artifacts 
         for i in range(0, numToPost):
                 #stop early if bounties to post is greater than the number of files
@@ -50,7 +50,7 @@ def postBounties(numToPost, files, host, keyfile, password, bid, duration, api_k
 
                 tempBounty = artifactArr[curArtifact]
                 tempBounty.postBounty(duration, keyfile, password, account)
-                logging.debug('posted bounty with nonce '+ str(nonce))
+                logging.info('posted bounty with nonce '+ str(nonce))
                 bountyArr.append(tempBounty)
                 curArtifact+=1
         return bountyArr
@@ -70,19 +70,19 @@ def getFiles(directory):
 def run_test(polyswarmd_addr, keyfile, password, bounty_directory, bid, duration, api_key, account):
     #default bounties to post
 
-    logging.debug("\n\n********************************")
-    logging.debug("OBTAINING FILES")
-    logging.debug("********************************")
+    logging.info("\n\n********************************")
+    logging.info("OBTAINING FILES")
+    logging.info("********************************")
     fileList = getFiles(bounty_directory)
-    logging.debug(os.listdir(bounty_directory))
-    logging.debug("\n\n******************************************************")
-    logging.debug("CREATING "+ str(len(fileList)) + "BOUNTIES")
-    logging.debug("********************************************************")
+    logging.info(os.listdir(bounty_directory))
+    logging.info("\n\n******************************************************")
+    logging.info("CREATING "+ str(len(fileList)) + "BOUNTIES")
+    logging.info("********************************************************")
     bountyList = postBounties(len(fileList), fileList, polyswarmd_addr, keyfile, password, bid, duration, api_key, account)
-    logging.debug( str(bountyList) )
-    logging.debug("\n\n********************************")
-    logging.debug("FINISHED BOUNTY CREATION, EXITING AMBASSADOR")
-    logging.debug("********************************\n\n")
+    logging.info( str(bountyList) )
+    logging.info("\n\n********************************")
+    logging.info("FINISHED BOUNTY CREATION, EXITING AMBASSADOR")
+    logging.info("********************************\n\n")
 
 if __name__ == "__main__":
     run_test()


### PR DESCRIPTION
This adds an offer channel integration test to our `e2e` build :cowboy_hat_face: :woman_office_worker: :soccer: 

The process for the test is as follows:

1. The `ambassador` (after posting bounties) **[creates](https://docs.polyswarm.io/API-polyswarm/#create-an-offer-channel)** and **[opens](https://docs.polyswarm.io/API-polyswarm/#open-channel)** an offer channel.
2. After the offer channel is joined from the `microengine` the `ambassador` tries to cheat and changes the offer payout to `0` nectar.
3. This theft attempt triggers a **[dispute](https://docs.polyswarm.io/API-polyswarm/#settle-channel)** in the channel from the `microengine`. Since the ambassador has no newer signed channel state it loses to the `microengine` state's higher nonce after the dispute reply period set by the `amabbassaor` `10` blocks.
4.  The `microengine` **[closes the disputed channel](https://docs.polyswarm.io/API-polyswarm/#close-challenged-channel-with-timeout)** after `10` blocks.
5. A new offer channel is made but this time with good intentions. This offer channel runs until completing `N` (defined by `--testing`) offers in the `ambassador` and `microengine`.
6. The `ambassador` **[closes](https://docs.polyswarm.io/API-polyswarm/#close-channel)** the channel and **`exits 0`**

note: testing offers requires the `--offers` flag on `ambassadors.py`
